### PR TITLE
Use Spacy instead of Corenlp

### DIFF
--- a/process.py
+++ b/process.py
@@ -32,14 +32,12 @@ parser.add_argument('-p','--process', default = False, type = str2bool, help='Us
 args = parser.parse_args()
 
 if args.process:
-    from stanford_corenlp_pywrapper import CoreNLP
-    proc = CoreNLP("ssplit",corenlp_jars=[Params.coreNLP_dir + "/*"])
+    import spacy
+    nlp = spacy.load('en')
 
     def tokenize_corenlp(text):
-        parsed = proc.parse_doc(text)
-        tokens = []
-        for sent in parsed['sentences']:
-            tokens.extend(sent['tokens'])
+        parsed = nlp(text)
+        tokens = [i.text for i in parsed]
         return tokens
 
 class data_loader(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nltk==3.2.4
 numpy==1.13.1
 tqdm==4.15.0
+spacy

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,6 @@
 mkdir data
 wget -P data https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
 wget -P data https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
-wget http://nlp.stanford.edu/software/stanford-corenlp-full-2017-06-09.zip
 wget http://nlp.stanford.edu/data/glove.840B.300d.zip
-unzip stanford-corenlp-full-2017-06-09.zip
 unzip glove.840B.300d.zip
-rm stanford-corenlp-full-2017-06-09.zip
 rm glove.840B.300d.zip
-git clone https://github.com/brendano/stanford_corenlp_pywrapper
-cd stanford_corenlp_pywrapper
-pip install .
-mv stanford_corenlp_pywrapper/* ./
-cd ..


### PR DESCRIPTION
Reduces setup memory usage and is way faster. Unless we're trying to maintain paper compatibility that is.